### PR TITLE
Fix roll() method to print message when all dice are locked (Issue #3)

### DIFF
--- a/yatzy.py
+++ b/yatzy.py
@@ -7,10 +7,12 @@ class Yatzy:
         self.roll()
 
     def roll(self):
+        if all(self.locked):  # Check if all dice are locked
+            print("All dice are locked, cannot roll!")
+            return  # Exit the method
         for i in range(5):
             if not self.locked[i]:
                 self.dice[i] = random.randint(1, 6)
-
     def lock_die(self, index):
         if 0 <= index < 5:
             self.locked[index] = True
@@ -110,3 +112,6 @@ class Yatzy:
         if all(d == self.dice[0] for d in self.dice):
             return 50
         return 0
+    
+
+      


### PR DESCRIPTION
This PR fixes Issue #3. The `roll()` method now prints "All dice are locked, cannot roll!" if all dice are locked, so the user knows why the dice didn’t change.

- Added a check in `roll()` using `all(self.locked)`.
- Tested the fix manually with `yatzy_game.py`.